### PR TITLE
udpated query to work with neo4j >= 4.0

### DIFF
--- a/neo4jupyter.py
+++ b/neo4jupyter.py
@@ -71,7 +71,7 @@ def draw(graph, options, physics=True, limit=100):
     MATCH (n)
     WITH n, rand() AS random
     ORDER BY random
-    LIMIT {limit}
+    LIMIT $limit
     OPTIONAL MATCH (n)-[r]->(m)
     RETURN n AS source_node,
            id(n) AS source_id,


### PR DESCRIPTION
ability to use {param} was removed; use $param instead